### PR TITLE
fix: fix movement of extras to json_schema_extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ pydantic version installed (without deprecation warnings):
   | `max_items`      | `max_length`        |
   | `regex`          | `pattern`           |
   | `allow_mutation` | `not frozen`        |
-  | `metadata`       | `json_schema_extra` |
+  | `<extra_key>`       | `json_schema_extra['<extra_key>']` |
 - Don't use `var = Field(..., const='val')`, use `var: Literal['val'] = 'val'`
   it works in both v1 and v2
 - No attempt is made to convert between v1's `unique_items` and v2's `Set[]`

--- a/src/pydantic_compat/_shared.py
+++ b/src/pydantic_compat/_shared.py
@@ -1,11 +1,17 @@
 import contextlib
 import warnings
+from inspect import signature
 from typing import Any
 
 import pydantic
 import pydantic.version
 
 PYDANTIC2 = pydantic.version.VERSION.startswith("2")
+FIELD_KWARGS = {
+    p.name
+    for p in signature(pydantic.Field).parameters.values()
+    if p.kind != p.VAR_KEYWORD
+}
 
 V2_REMOVED_CONFIG_KEYS = {
     "allow_mutation",
@@ -37,7 +43,7 @@ V1_FIELDS_TO_V2_FIELDS = {
     "max_items": "max_length",
     "regex": "pattern",
     "allow_mutation": "-frozen",
-    "metadata": "json_schema_extra",
+    # "metadata": "json_schema_extra['metadata']",  # needs special handling
 }
 
 V2_FIELDS_TO_V1_FIELDS = {}
@@ -89,8 +95,25 @@ def clean_field_kwargs(kwargs: dict) -> dict:
     return kwargs
 
 
+if PYDANTIC2:
+
+    def move_extras(kwargs: dict) -> dict:
+        """Move extra field arguments to json_schema_extra."""
+        extras = {k: kwargs.pop(k) for k in list(kwargs) if k not in FIELD_KWARGS}
+        kwargs.setdefault("json_schema_extra", {}).update(extras)
+        return kwargs
+
+else:
+
+    def move_extras(kwargs: dict) -> dict:
+        """Move unknown json_schema_extra fields to extras."""
+        kwargs.update(kwargs.pop("json_schema_extra", {}))
+        return kwargs
+
+
 def Field(*args: Any, **kwargs: Any) -> Any:
     """Create a field for objects that can be configured."""
-    kwargs = clean_field_kwargs(kwargs)
-    kwargs = move_field_kwargs(kwargs)
+    kwargs = clean_field_kwargs(kwargs)  # remove outdated kwargs
+    kwargs = move_field_kwargs(kwargs)  # move kwargs from v1 to v2 and vice versa
+    kwargs = move_extras(kwargs)  # move extras to/from json_schema_extra
     return pydantic.Field(*args, **kwargs)

--- a/src/pydantic_compat/_shared.py
+++ b/src/pydantic_compat/_shared.py
@@ -43,7 +43,6 @@ V1_FIELDS_TO_V2_FIELDS = {
     "max_items": "max_length",
     "regex": "pattern",
     "allow_mutation": "-frozen",
-    # "metadata": "json_schema_extra['metadata']",  # needs special handling
 }
 
 V2_FIELDS_TO_V1_FIELDS = {}

--- a/src/pydantic_compat/_v1/mixin.py
+++ b/src/pydantic_compat/_v1/mixin.py
@@ -34,12 +34,6 @@ if TYPE_CHECKING:
         __config__: ClassVar[type]
     # fmt:on
 
-if sys.version_info < (3, 9):
-
-    def _get_fields(obj) -> dict[str, Any]:
-        return obj.__fields__
-
-    main.ModelMetaclass.model_fields = property(_get_fields)
 
 REVERSE_CONFIG_NAME_MAP = {v: k for k, v in V2_RENAMED_CONFIG_KEYS.items()}
 
@@ -58,6 +52,12 @@ class _MixinMeta(main.ModelMetaclass):
             namespace["Config"] = _convert_config(namespace.pop("model_config"))
 
         return super().__new__(cls, name, bases, namespace, **kwargs)
+
+    if sys.version_info < (3, 9):
+
+        @property
+        def model_fields(cls) -> dict[str, Any]:
+            return FieldInfoMap(cls.__fields__)
 
 
 class PydanticCompatMixin(metaclass=_MixinMeta):

--- a/src/pydantic_compat/_v1/mixin.py
+++ b/src/pydantic_compat/_v1/mixin.py
@@ -136,8 +136,15 @@ class FieldInfoLike:
     def frozen(self) -> bool:
         return not self._model_field.field_info.allow_mutation
 
+    @property
+    def json_schema_extra(self) -> dict:
+        return self._model_field.field_info.extra
+
     def __getattr__(self, key: str) -> Any:
         return getattr(self._model_field, key)
+
+    def __repr__(self) -> str:
+        return repr(self._model_field)
 
 
 class FieldInfoMap(Mapping[str, FieldInfoLike]):

--- a/src/pydantic_compat/_v1/mixin.py
+++ b/src/pydantic_compat/_v1/mixin.py
@@ -138,7 +138,7 @@ class FieldInfoLike:
 
     @property
     def json_schema_extra(self) -> dict:
-        return self._model_field.field_info.extra
+        return self._model_field.field_info.extra  # type: ignore [no-any-return]
 
     def __getattr__(self, key: str) -> Any:
         return getattr(self._model_field, key)

--- a/tests/test_base_model.py
+++ b/tests/test_base_model.py
@@ -3,14 +3,14 @@ from typing import ClassVar
 import pydantic
 import pytest
 
-from pydantic_compat import PydanticCompatMixin
+from pydantic_compat import PYDANTIC2, PydanticCompatMixin
 
 
 class Model(PydanticCompatMixin, pydantic.BaseModel):
     x: int = 1
 
 
-def test_v1_api():
+def test_v1_api() -> None:
     m = Model()
     assert m.x == 1
     assert m.dict() == {"x": 1}
@@ -32,7 +32,7 @@ def test_v1_api():
     Model.update_forward_refs(name="name")
 
 
-def test_v2_api():
+def test_v2_api() -> None:
     m = Model()
     assert m.x == 1
     assert m.model_dump() == {"x": 1}
@@ -53,7 +53,7 @@ def test_v2_api():
     Model.model_rebuild(force=True)
 
 
-def test_v1_attributes():
+def test_v1_attributes() -> None:
     m = Model()
     assert "x" in m.__fields__
     assert "x" in Model.__fields__
@@ -62,7 +62,7 @@ def test_v1_attributes():
     assert "x" in m.__fields_set__
 
 
-def test_v2_attributes():
+def test_v2_attributes() -> None:
     m = Model()
     assert "x" in m.model_fields
     assert "x" in Model.model_fields
@@ -70,8 +70,15 @@ def test_v2_attributes():
     m.x = 2
     assert "x" in m.model_fields_set
 
+    if not PYDANTIC2:
+        from pydantic_compat._v1.mixin import FieldInfoMap
 
-def test_mixin_order():
+        assert isinstance(Model.model_fields, FieldInfoMap)
+    else:
+        assert isinstance(Model.model_fields, dict)
+
+
+def test_mixin_order() -> None:
     with pytest.warns(
         match="PydanticCompatMixin should appear before pydantic.BaseModel"
     ):
@@ -94,7 +101,7 @@ class V1Config:
 
 
 @pytest.mark.parametrize("config", [V1Config, V2Config])
-def test_config(config):
+def test_config(config: object) -> None:
     class Model1(PydanticCompatMixin, pydantic.BaseModel):
         name: str = pydantic.Field(alias="full_name")
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -3,7 +3,7 @@ from typing import ClassVar, List, Tuple
 import pytest
 from typing_extensions import Literal
 
-from pydantic_compat import PYDANTIC2, BaseModel, Field
+from pydantic_compat import BaseModel, Field
 
 
 def test_field_const() -> None:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -3,7 +3,7 @@ from typing import ClassVar, List, Tuple
 import pytest
 from typing_extensions import Literal
 
-from pydantic_compat import BaseModel, Field
+from pydantic_compat import PYDANTIC2, BaseModel, Field
 
 
 def test_field_const() -> None:
@@ -87,3 +87,10 @@ def test_double_usage_raises(keys: Tuple[str, str]) -> None:
 #         bar: List[int] = Field(..., unique_items=True)
 #     with pytest.raises(ValueError):
 #         Foo(bar=[1, 2, 3, 1])
+
+
+def test_field_extras() -> None:
+    class Foo(BaseModel):
+        bar: int = Field(..., metadata={"foo": "bar"})  # type: ignore
+
+    assert Foo.model_fields["bar"].json_schema_extra["metadata"] == {"foo": "bar"}


### PR DESCRIPTION
there's a bug in the handling of extra kwargs to Fields.

This PR makes it so that `**extras` are added to `json_schema_extra` (i.e. with `update`), instead of the key `metadata`